### PR TITLE
Disable zoom and scroll on google maps popup

### DIFF
--- a/src/components/DetailDialog/DetailMap.jsx
+++ b/src/components/DetailDialog/DetailMap.jsx
@@ -26,6 +26,7 @@ const Map = ({
                     streetViewControl: false,
                     fullscreenControl: false,
                     zoomControl: false,
+                    draggable: false
                 }}
                 zoom={15}
                 center={{


### PR DESCRIPTION
https://trello.com/c/ATCHqCsf/161-disable-scroll-and-zoom-on-maps-for-service-popup